### PR TITLE
Fix PDO credential usage

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -3,6 +3,8 @@ include 'private.php';
 
 
 function pdo_connect_mysql() {
+    // Use the database credentials defined in private.php
+    global $db_host, $db_user, $db_pass, $db_name;
     $DATABASE_HOST = $db_host;
     $DATABASE_USER = $db_user;
     $DATABASE_PASS = $db_pass;


### PR DESCRIPTION
## Summary
- ensure the global DB config variables from `private.php` are accessible inside `pdo_connect_mysql`

## Testing
- `php -l functions.php`

------
https://chatgpt.com/codex/tasks/task_e_687fed086658832c83a7d7bd234eabb2