### PR TITLE
Fix heredoc terminator indentation

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -33,12 +33,12 @@ function template_header($title) {
                 <a href="read.php"><i class="fas fa-address-book"></i>Contacts</a>
             </div>
         </nav>
-    EOT;
+EOT;
     }
     function template_footer() {
     echo <<<EOT
         </body>
     </html>
-    EOT;
+EOT;
     }
     ?>


### PR DESCRIPTION
## Summary
- adjust heredoc terminator indentations in `template_header` and `template_footer`

## Testing
- `php -l functions.php`


------
https://chatgpt.com/codex/tasks/task_e_687ff01cf9e4832c92ccc76fc0589a2c